### PR TITLE
Update android.yml

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,9 +2,11 @@ name: Android CI
 
 on:
   push:
-    branches: [ main ]
+    branches-ignore:
+      - '**-nocheck'
   pull_request:
-    branches: [ main ]
+    branches-ignore:
+      - '**-nocheck'
 
 jobs:
   build:


### PR DESCRIPTION
_proposed change to actions:_

from now on, Android-CI check will run on all pushes to all branches. In order to turn off checks for your branch, add `-nocheck` to the end of your branch name.